### PR TITLE
Remove trailing dot in config mapping prefix

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/zanzibar/deployment/ZanzibarConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/zanzibar/deployment/ZanzibarConfig.java
@@ -9,7 +9,7 @@ import io.smallrye.config.ConfigMapping;
 @ConfigMapping(prefix = ZanzibarConfig.PREFIX)
 public interface ZanzibarConfig {
 
-    String PREFIX = "quarkus." + FEATURE + ".";
+    String PREFIX = "quarkus." + FEATURE;
 
     /**
      * Configuration for JAX-RS authorization filter.


### PR DESCRIPTION
It created an empty path in _some_ configuration situations (e.g., `quarkus.zanzibar..filter…`)