### PR TITLE
Update OpenFGA and Authzed dependencies

### DIFF
--- a/zanzibar-authzed/pom.xml
+++ b/zanzibar-authzed/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
   <name>Quarkus Zanzibar - Authzed - Parent</name>
   <properties>
-    <authzed.version>0.6.0</authzed.version>
+    <authzed.version>0.7.0</authzed.version>
   </properties>
   <modules>
     <module>deployment</module>

--- a/zanzibar-openfga/pom.xml
+++ b/zanzibar-openfga/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
   <name>Quarkus Zanzibar - OpenFGA - Parent</name>
   <properties>
-    <openfga.version>2.0.0</openfga.version>
+    <openfga.version>2.1.0</openfga.version>
   </properties>
   <modules>
     <module>deployment</module>


### PR DESCRIPTION
Uses 3.15.1 compatible builds for both.