### PR TITLE
Update OpenFGA to 3.0.0-RC and add simple context injection

### DIFF
--- a/zanzibar-openfga/integration-tests/src/main/java/io/quarkiverse/zanzibar/openfga/it/ZanzibarOpenFGAResource.java
+++ b/zanzibar-openfga/integration-tests/src/main/java/io/quarkiverse/zanzibar/openfga/it/ZanzibarOpenFGAResource.java
@@ -20,17 +20,25 @@ import static io.quarkiverse.zanzibar.annotations.FGADynamicObject.Source.PATH;
 import static io.quarkiverse.zanzibar.annotations.FGARelation.ANY;
 
 import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.openfga.client.AuthorizationModelClient;
+import io.quarkiverse.openfga.client.model.RelTupleKey;
 import io.quarkiverse.zanzibar.Relationship;
 import io.quarkiverse.zanzibar.RelationshipContext;
 import io.quarkiverse.zanzibar.RelationshipManager;
 import io.quarkiverse.zanzibar.annotations.FGADynamicObject;
 import io.quarkiverse.zanzibar.annotations.FGARelation;
 import io.quarkiverse.zanzibar.annotations.FGAUserType;
+import io.quarkiverse.zanzibar.openfga.OpenFGAContextSupplier;
 import io.smallrye.mutiny.Uni;
 
 @FGADynamicObject(source = PATH, sourceProperty = "id", type = "thing")
@@ -89,5 +97,18 @@ public class ZanzibarOpenFGAResource implements Things {
     @Path("jwt/things/{id}")
     public String jwtGetThing(@PathParam("id") String id) {
         return "Thing " + id;
+    }
+}
+
+@ApplicationScoped
+class ContextSupplier implements OpenFGAContextSupplier {
+
+    @Inject
+    Logger logger;
+
+    @Override
+    public Result getContext(@Nonnull AuthorizationModelClient client, @Nonnull RelTupleKey relTupleKey) {
+        logger.info("getContext called");
+        return new Result(Map.of(), List.of());
     }
 }

--- a/zanzibar-openfga/runtime/src/main/java/io/quarkiverse/zanzibar/openfga/OpenFGAContextSupplier.java
+++ b/zanzibar-openfga/runtime/src/main/java/io/quarkiverse/zanzibar/openfga/OpenFGAContextSupplier.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.zanzibar.openfga;
+
+import java.util.Collection;
+import java.util.Map;
+
+import io.quarkiverse.openfga.client.AuthorizationModelClient;
+import io.quarkiverse.openfga.client.model.RelTupleDefinition;
+import io.quarkiverse.openfga.client.model.RelTupleKey;
+
+/**
+ * Supplies the context for a given relationship tuple.
+ * <p>
+ * Application's wishing to use OpenFGA context capabilities (e.g., conditions) must provide an implementation
+ * via CDI. The {@link #getContext(AuthorizationModelClient, RelTupleKey)} method will be called before each
+ * authorization check to obtain the context for the given relationship tuple. This only manages the context
+ * for authorization checks, not the relationship tuples themselves, which must be created/updated via the
+ * OpenFGA API externally.
+ */
+public interface OpenFGAContextSupplier {
+
+    record Result(Map<String, Object> context, Collection<RelTupleDefinition> contextualTuples) {
+    }
+
+    /**
+     * Supplies the context for the given relationship tuple.
+     *
+     * @param client the OpenFGA client
+     * @param relTupleKey the relationship tuple key
+     * @return the context to use for the given relationship tuple
+     */
+    Result getContext(AuthorizationModelClient client, RelTupleKey relTupleKey);
+
+}

--- a/zanzibar-openfga/runtime/src/main/java/io/quarkiverse/zanzibar/openfga/ZanzibarOpenFGARelationshipManager.java
+++ b/zanzibar-openfga/runtime/src/main/java/io/quarkiverse/zanzibar/openfga/ZanzibarOpenFGARelationshipManager.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import io.quarkiverse.openfga.client.AuthorizationModelClient;
+import io.quarkiverse.openfga.client.AuthorizationModelClient.CheckOptions;
 import io.quarkiverse.openfga.client.model.RelObject;
 import io.quarkiverse.openfga.client.model.RelTupleDefinition;
 import io.quarkiverse.openfga.client.model.RelTupleKey;
@@ -19,17 +21,32 @@ import io.smallrye.mutiny.Uni;
 public class ZanzibarOpenFGARelationshipManager implements RelationshipManager {
 
     private final AuthorizationModelClient authorizationModelClient;
+    private final OpenFGAContextSupplier contextSupplier;
 
     @Inject
-    public ZanzibarOpenFGARelationshipManager(AuthorizationModelClient authorizationModelClient) {
+    public ZanzibarOpenFGARelationshipManager(AuthorizationModelClient authorizationModelClient,
+            Instance<OpenFGAContextSupplier> contextSuppliers) {
         this.authorizationModelClient = authorizationModelClient;
+        if (contextSuppliers.isResolvable()) {
+            this.contextSupplier = contextSuppliers.get();
+        } else {
+            this.contextSupplier = null;
+        }
     }
 
     public Uni<Boolean> check(Relationship relationship) {
 
         var relTupleKey = tupleKeyFromRelationship(relationship);
 
-        return authorizationModelClient.check(relTupleKey);
+        CheckOptions options = CheckOptions.DEFAULT;
+        if (contextSupplier != null) {
+
+            var supplied = contextSupplier.getContext(authorizationModelClient, relTupleKey);
+
+            options = CheckOptions.withContext(supplied.context()).contextualTuples(supplied.contextualTuples());
+        }
+
+        return authorizationModelClient.check(relTupleKey, options);
     }
 
     @Override


### PR DESCRIPTION
## OpenFGA Context Injection
Applications can provide and implementation of `OpenFGAContextSupplier` to add context (condition values and/or contextual tuples) prior to executing the authorization check.
