### PR TITLE
Bump OpenFGA version from 3.12.0 to 3.12.1

### DIFF
--- a/zanzibar-openfga/pom.xml
+++ b/zanzibar-openfga/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
   <name>Quarkus Zanzibar - OpenFGA - Parent</name>
   <properties>
-    <openfga.version>3.12.0</openfga.version>
+    <openfga.version>3.12.1</openfga.version>
   </properties>
   <modules>
     <module>deployment</module>


### PR DESCRIPTION
Includes fix for caching of failed storeId lookups