### PR TITLE
Guard null principal names in DefaultUserExtractor

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -31,6 +31,11 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/runtime/src/main/java/io/quarkiverse/zanzibar/DefaultUserExtractor.java
+++ b/runtime/src/main/java/io/quarkiverse/zanzibar/DefaultUserExtractor.java
@@ -54,6 +54,10 @@ public class DefaultUserExtractor implements UserExtractor {
     UserInfo extractUserInfoFromPrincipal(Principal principal) {
 
         var name = principal.getName();
+        if (name == null) {
+            return new UserInfo(Optional.empty(), Optional.empty());
+        }
+
         if (extractUserTypeFromName) {
             var parts = name.split(userTypeSeparator);
             if (parts.length != 2) {

--- a/runtime/src/test/java/io/quarkiverse/zanzibar/DefaultUserExtractorTest.java
+++ b/runtime/src/test/java/io/quarkiverse/zanzibar/DefaultUserExtractorTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.zanzibar;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.Principal;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultUserExtractorTest {
+
+    @Test
+    void returnsEmptyUserWhenPrincipalNameIsNullAndUserTypeIsExtractedFromName() {
+        var extractor = new DefaultUserExtractor(true, ":", false);
+
+        var user = extractor.extractUser(new NullNamePrincipal(), null);
+
+        assertTrue(user.isEmpty());
+    }
+
+    private static final class NullNamePrincipal implements Principal {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added a null check in `DefaultUserExtractor.extractUserInfoFromPrincipal` so a principal with no name no longer triggers an NPE when name-based user type extraction is enabled.
- Preserved the existing fallback flow by returning an empty user info result when the principal name is null.
- Added a focused runtime unit test covering a null `Principal.getName()` case.
- Added the runtime test dependency needed to execute the new JUnit test.

## Testing
- Runtime module unit tests passed locally with `mise exec -- mvn -pl runtime test`.